### PR TITLE
Resolve "supabase integration for favourites and watchlist"

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -11,7 +11,8 @@
     "react-dom": "^18.0.1",
     "react-hook-form": "^7.34.2",
     "react-query": "^3.13.0",
-    "react-router-dom": "6.3.0"
+    "react-router-dom": "6.3.0",
+    "@supabase/supabase-js": "^2.11.0"
   },
   "scripts": {
     "storybook": "cross-env NODE_OPTIONS=--openssl-legacy-provider start-storybook -p 6006 -s public",

--- a/app/src/api/supabase.js
+++ b/app/src/api/supabase.js
@@ -1,0 +1,17 @@
+import { supabaseClient } from "../utils/client";
+
+// Function to select ids from a given table, parse result and add to array to return
+// intended to be used to set up state for favourites and watchlist
+export const getUserSelection = async (table) => {
+    let idArray = [];
+    let { data, error } = await supabaseClient.from(table).select("id");
+    if(!error){
+        for(var key in data){
+            idArray.push(data[key].id);
+        }
+        console.log(idArray);
+        return idArray; 
+    }else{
+        throw error;
+    }
+}

--- a/app/src/api/tmdb-api.js
+++ b/app/src/api/tmdb-api.js
@@ -27,7 +27,6 @@
   };
   
   export const getMovie = (args) => {
-    // console.log(args)
     const [, idPart] = args.queryKey;
     const { id } = idPart;
     return fetch(

--- a/app/src/components/movieCard/index.jsx
+++ b/app/src/components/movieCard/index.jsx
@@ -19,7 +19,7 @@ import { MoviesContext } from "../../contexts/moviesContext";
 const styles = {
   card: { maxWidth: 345 },
   media: { height: 500 },
-  fav_avatar: {
+  avatar: {
     backgroundColor: "rgb(255, 0, 0)",
   },
   watch_avatar: {
@@ -49,14 +49,14 @@ export default function MovieCard({ movie, action }) {
       <CardHeader
         sx={styles.header}
         avatar={
-          movie.favorite ? (
-            <Avatar sx={styles.fav_avatar}>
+          movie.favourite ? (
+            <Avatar sx={styles.avatar}>
               <FavoriteIcon />
             </Avatar>
-          ) : movie.watchlist ? 
+          ) : movie.watchlist ? (
           <Avatar sx={styles.watch_avatar}>
             <ListIcon />
-          </Avatar> : null
+          </Avatar> ) : null
         }
         title={
           <Typography variant="h5" component="p">

--- a/app/src/contexts/moviesContext.jsx
+++ b/app/src/contexts/moviesContext.jsx
@@ -12,12 +12,15 @@ const MoviesContextProvider = (props) => {
     try{
         let updatedFavourites = [...favourites];
         if(!favourites.includes(movie.id)) {
-          //add to server state
-          updatedFavourites.push(movie.id)
           // add to supabase DB table "favourites"
           let { error } = await supabaseClient
             .from("favourites").insert({movie_id: movie.id})
-          if(error){throw error}
+          // if no error returned from supabase, add to server state
+          if(!error){
+            updatedFavourites.push(movie.id)
+          }else{
+            throw error
+          }
         }
         setFavourites(updatedFavourites);
     } catch (err) {

--- a/app/src/contexts/moviesContext.jsx
+++ b/app/src/contexts/moviesContext.jsx
@@ -31,30 +31,55 @@ const MoviesContextProvider = (props) => {
   const removeFromFavourites = async (movie) => {
     try{
       let { error } = await supabaseClient
-      .from("favourites").delete().eq("movie_id", movie.id);
+        .from("favourites").delete().eq("movie_id", movie.id);
+
       if(!error){
         //remove from server state
         setFavourites(favourites.filter((mId) => mId !== movie.id));
       }else{
         throw error;
       }
+    
     }catch(err){
       console.log(err);
     }
   };
 
-  const addToWatchlist = (movie) => {
-    let updatedWatchlist = [...watchlist];
-    if(!watchlist.includes(movie.id)) {
-      updatedWatchlist.push(movie.id);
+  const addToWatchlist = async (movie) => {
+    try{
+      let updatedWatchlist = [...watchlist];
+      if(!watchlist.includes(movie.id)) {
+        let { error } = await supabaseClient
+        .from("watchlist").insert({movie_id: movie.id});
+      
+        if(!error){
+          updatedWatchlist.push(movie.id)
+        }else{
+          throw error;
+        }
+      }
+      setWatchlist(updatedWatchlist);
+    }catch(err){
+      console.log(err);
     }
-    setWatchlist(updatedWatchlist);
   }
 
-  const removeFromWatchlist = (movie) => {
-    setWatchlist(watchlist.filter((mId) => mId !== movie.id));
-  }
+  const removeFromWatchlist = async (movie) => {
+    try{
+      let { error } = await supabaseClient
+        .from("watchlist").delete().eq("movie_id", movie.id);
+      
+      if(!error){
+        setWatchlist(watchlist.filter((mId) => mId !== movie.id));
+      }else{
+        throw error;
+      }
 
+    }catch(err){
+      console.log(err);
+    }
+  }
+  
   const addReview = (movie, review) => { 
     setMyReviews( {...myReviews, [movie.id]: review } )
   };

--- a/app/src/contexts/moviesContext.jsx
+++ b/app/src/contexts/moviesContext.jsx
@@ -1,20 +1,25 @@
 import React, { useState } from "react";
+import { getUserSelection } from "../api/supabase";
 import { supabaseClient } from "../utils/client";
 
 export const MoviesContext = React.createContext(null);
 
+const userFavourites = await getUserSelection("favourites");
+const userWatchlist = await getUserSelection("watchlist");
+
 const MoviesContextProvider = (props) => {
-  const [favourites, setFavourites] = useState([]);
-  const [watchlist, setWatchlist] = useState([]);
+  const [favourites, setFavourites] = useState(userFavourites);
+  const [watchlist, setWatchlist] = useState(userWatchlist);
   const [myReviews, setMyReviews] = useState( {} )
 
   const addToFavourites = async (movie) => {
     try{
+      console.log("FAVS: ", favourites);
         let updatedFavourites = [...favourites];
         if(!favourites.includes(movie.id)) {
           // add to supabase DB table "favourites"
           let { error } = await supabaseClient
-            .from("favourites").insert({movie_id: movie.id});
+            .from("favourites").insert({id: movie.id});
           // if no error returned from supabase, add to server state
           if(!error){
             updatedFavourites.push(movie.id);
@@ -31,7 +36,7 @@ const MoviesContextProvider = (props) => {
   const removeFromFavourites = async (movie) => {
     try{
       let { error } = await supabaseClient
-        .from("favourites").delete().eq("movie_id", movie.id);
+        .from("favourites").delete().eq("id", movie.id);
 
       if(!error){
         //remove from server state
@@ -50,7 +55,7 @@ const MoviesContextProvider = (props) => {
       let updatedWatchlist = [...watchlist];
       if(!watchlist.includes(movie.id)) {
         let { error } = await supabaseClient
-        .from("watchlist").insert({movie_id: movie.id});
+        .from("watchlist").insert({id: movie.id});
       
         if(!error){
           updatedWatchlist.push(movie.id)
@@ -67,7 +72,7 @@ const MoviesContextProvider = (props) => {
   const removeFromWatchlist = async (movie) => {
     try{
       let { error } = await supabaseClient
-        .from("watchlist").delete().eq("movie_id", movie.id);
+        .from("watchlist").delete().eq("id", movie.id);
       
       if(!error){
         setWatchlist(watchlist.filter((mId) => mId !== movie.id));

--- a/app/src/contexts/moviesContext.jsx
+++ b/app/src/contexts/moviesContext.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { supabaseClient } from "../utils/client";
 
 export const MoviesContext = React.createContext(null);
 
@@ -7,15 +8,25 @@ const MoviesContextProvider = (props) => {
   const [watchlist, setWatchlist] = useState([]);
   const [myReviews, setMyReviews] = useState( {} )
 
-  const addToFavourites = (movie) => {
-    let updatedFavourites = [...favourites];
-    if (!favourites.includes(movie.id)) {
-      updatedFavourites.push(movie.id);
+  const addToFavourites = async (movie) => {
+    try{
+        let updatedFavourites = [...favourites];
+        if(!favourites.includes(movie.id)) {
+          //add to server state
+          updatedFavourites.push(movie.id)
+          // add to supabase DB table "favourites"
+          let { error } = await supabaseClient
+            .from("favourites").insert({movie_id: movie.id})
+          if(error){throw error}
+        }
+        setFavourites(updatedFavourites);
+    } catch (err) {
+      console.log(err)
     }
-    setFavourites(updatedFavourites);
-  };
+  }
 
   const removeFromFavourites = (movie) => {
+    //remove from server state
     setFavourites(favourites.filter((mId) => mId !== movie.id));
   };
 

--- a/app/src/contexts/moviesContext.jsx
+++ b/app/src/contexts/moviesContext.jsx
@@ -14,23 +14,33 @@ const MoviesContextProvider = (props) => {
         if(!favourites.includes(movie.id)) {
           // add to supabase DB table "favourites"
           let { error } = await supabaseClient
-            .from("favourites").insert({movie_id: movie.id})
+            .from("favourites").insert({movie_id: movie.id});
           // if no error returned from supabase, add to server state
           if(!error){
-            updatedFavourites.push(movie.id)
+            updatedFavourites.push(movie.id);
           }else{
-            throw error
+            throw error;
           }
         }
         setFavourites(updatedFavourites);
     } catch (err) {
-      console.log(err)
+      console.log(err);
     }
   }
 
-  const removeFromFavourites = (movie) => {
-    //remove from server state
-    setFavourites(favourites.filter((mId) => mId !== movie.id));
+  const removeFromFavourites = async (movie) => {
+    try{
+      let { error } = await supabaseClient
+      .from("favourites").delete().eq("movie_id", movie.id);
+      if(!error){
+        //remove from server state
+        setFavourites(favourites.filter((mId) => mId !== movie.id));
+      }else{
+        throw error;
+      }
+    }catch(err){
+      console.log(err);
+    }
   };
 
   const addToWatchlist = (movie) => {

--- a/app/src/contexts/moviesContext.jsx
+++ b/app/src/contexts/moviesContext.jsx
@@ -14,7 +14,6 @@ const MoviesContextProvider = (props) => {
 
   const addToFavourites = async (movie) => {
     try{
-      console.log("FAVS: ", favourites);
         let updatedFavourites = [...favourites];
         if(!favourites.includes(movie.id)) {
           // add to supabase DB table "favourites"

--- a/app/src/hooks/useMovie.js
+++ b/app/src/hooks/useMovie.js
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import {getMovie} from '../api/tmdb-api'
+import { getMovie } from '../api/tmdb-api'
 
 const useMovie = id => {
   const [movie, setMovie] = useState(null);

--- a/app/src/utils/client.js
+++ b/app/src/utils/client.js
@@ -1,0 +1,3 @@
+import { createClient } from "@supabase/supabase-js";
+
+export const supabaseClient = createClient(import.meta.env.VITE_SUPABASE_URL, import.meta.env.VITE_SUPABASE_KEY)


### PR DESCRIPTION
## Description

The changes made in this issue add simple Supabase integration for both the favourites and watchlist functionality. In this way, the users selection is persisted, and functionality has been added to seed the server state with the favourites and watchlist ids from the database on page load/reload.

The work to be done here is to verify that adding, removing favourites and watchlist items are working as intended.

## Tests

### Test 1 - Verify favourites and watchlist persisted are displayed

There are some items in Supabase already for both favourites (3) and watchlist (2), these should display their respective icons on the discover and upcoming pages.

### Test 2 - Verify removal of favourites and watchlist items

Remove one item from each and verify that they are no longer displaying and are no longer in the database.

### Test 3 - Verify addition of favourite and watchlist 

Pick a random film from the discover to favourite, and from the upcoming page for the watchlist, and verify their id's are stored in the respective tables.

closes #10 