### PR TITLE
Resolve "Link favourites and watchlist items to users"

### DIFF
--- a/app/src/api/supabase.js
+++ b/app/src/api/supabase.js
@@ -16,3 +16,14 @@ export const getUserSelection = async (table, user) => {
         }
    }
 }
+
+// Function to return an item from a table
+// Can be used to return a specific item to process details, or check if a record exists
+export const returnItem = async (table, column, key, value) => {
+    let {data, error } = await supabaseClient.from(table).select(column).eq(key, value);
+    if(!error){
+        return data;
+    }else{
+        throw error;
+    }
+}

--- a/app/src/api/supabase.js
+++ b/app/src/api/supabase.js
@@ -2,15 +2,18 @@ import { supabaseClient } from "../utils/client";
 
 // Function to select ids from a given table, parse result and add to array to return
 // intended to be used to set up state for favourites and watchlist
-export const getUserSelection = async (table) => {
-    let idArray = [];
-    let { data, error } = await supabaseClient.from(table).select("id");
-    if(!error){
-        for(var key in data){
-            idArray.push(data[key].id);
+export const getUserSelection = async (table, user) => {
+   if(user){
+        let idArray = [];
+        let { data, error } = await supabaseClient.from(table).select("id").eq("user_id", user);
+        console.log("supabase return: ", data);
+        if(!error){
+            for(var key in data){
+                idArray.push(data[key].id);
+            }
+            return idArray; 
+        }else{
+            throw error;
         }
-        return idArray; 
-    }else{
-        throw error;
-    }
+   }
 }

--- a/app/src/api/supabase.js
+++ b/app/src/api/supabase.js
@@ -6,7 +6,6 @@ export const getUserSelection = async (table, user) => {
    if(user){
         let idArray = [];
         let { data, error } = await supabaseClient.from(table).select("id").eq("user_id", user);
-        console.log("supabase return: ", data);
         if(!error){
             for(var key in data){
                 idArray.push(data[key].id);

--- a/app/src/components/cardIcons/addToFavourites.jsx
+++ b/app/src/components/cardIcons/addToFavourites.jsx
@@ -2,13 +2,15 @@ import React, { useContext } from "react";
 import { MoviesContext } from "../../contexts/moviesContext";
 import IconButton from "@mui/material/IconButton";
 import FavoriteIcon from "@mui/icons-material/Favorite";
+import { useAuth } from "../../hooks/useAuth";
 
 const AddToFavouritesIcon = ({ movie }) => {
   const context = useContext(MoviesContext);
+  const { session }  = useAuth();
 
   const onUserSelect = (e) => {
     e.preventDefault();
-    context.addToFavourites(movie);
+    context.addToFavourites(movie, session?.user?.id);
   };
   return (
     <IconButton aria-label="add to favorites" onClick={onUserSelect}>

--- a/app/src/components/cardIcons/addToWatchlist.jsx
+++ b/app/src/components/cardIcons/addToWatchlist.jsx
@@ -2,13 +2,15 @@ import React, { useContext } from "react";
 import { MoviesContext } from "../../contexts/moviesContext";
 import IconButton from "@mui/material/IconButton";
 import PlaylistAddIcon from '@mui/icons-material/PlaylistAdd'
+import { useAuth } from "../../hooks/useAuth";
 
 const AddToWatchlistIcon = ({ movie }) => {
   const context = useContext(MoviesContext);
+  const { session }  = useAuth();
 
   const onUserSelect = (e) => {
     e.preventDefault();
-    context.addToWatchlist(movie);
+    context.addToWatchlist(movie, session?.user?.id);
   };
   return (
     <IconButton aria-label="add to watchlist" onClick={onUserSelect}>

--- a/app/src/components/cardIcons/removeFromFavourites.jsx
+++ b/app/src/components/cardIcons/removeFromFavourites.jsx
@@ -2,13 +2,15 @@ import React, { useContext } from "react";
 import IconButton from "@mui/material/IconButton";
 import DeleteIcon from "@mui/icons-material/Delete";
 import { MoviesContext } from "../../contexts/moviesContext";
+import { useAuth } from "../../hooks/useAuth";
 
 const RemoveFromFavouritesIcon = ({ movie }) => {
   const context = useContext(MoviesContext);
+  const { session }  = useAuth();
 
   const onUserRequest = (e) => {
     e.preventDefault();
-    context.removeFromFavourites(movie);
+    context.removeFromFavourites(movie, session?.user?.id);
   };
 
 return (

--- a/app/src/components/cardIcons/removeFromWatchlist.jsx
+++ b/app/src/components/cardIcons/removeFromWatchlist.jsx
@@ -2,13 +2,15 @@ import React, { useContext } from "react";
 import IconButton from "@mui/material/IconButton";
 import PlaylistRemoveIcon from '@mui/icons-material/PlaylistRemove';
 import { MoviesContext } from "../../contexts/moviesContext";
+import { useAuth } from "../../hooks/useAuth";
 
 const RemoveFromWatchlistIcon = ({ movie }) => {
   const context = useContext(MoviesContext);
+  const { session }  = useAuth();
 
   const onUserRequest = (e) => {
     e.preventDefault();
-    context.removeFromWatchlist(movie);
+    context.removeFromWatchlist(movie, session?.user?.id);
   };
 
 return (

--- a/app/src/components/cardIcons/signIn.jsx
+++ b/app/src/components/cardIcons/signIn.jsx
@@ -4,11 +4,11 @@ import Button from "@mui/material/Button";
 import GoogleIcon from '@mui/icons-material/Google';
 
 const SignIn = () => {
-  const context = useContext(AuthContext);
+  const authContext = useContext(AuthContext);
 
-  const handleLogin = async (e) => {
+  const handleLogin = (e) => {
     e.preventDefault();
-    await context.signIn();
+    authContext.signIn();
   }
 
   return (

--- a/app/src/components/siteHeader/index.jsx
+++ b/app/src/components/siteHeader/index.jsx
@@ -13,7 +13,6 @@ import { useNavigate } from "react-router-dom";
 import { useTheme } from "@mui/material/styles";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import { useAuth } from "../../hooks/useAuth";
-import { MoviesContext } from "../../contexts/moviesContext";
 
 const styles = {
   title: {
@@ -35,11 +34,6 @@ const SiteHeader = () => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("lg"));
   const { session }  = useAuth();
-  const moviesContext = useContext(MoviesContext);
-
-  useEffect(() => {
-    moviesContext.getUserFavourites(session?.user?.id);
-  }, []);
 
   const limitedOptions = [
     { label: "Home", path: "/" },

--- a/app/src/components/siteHeader/index.jsx
+++ b/app/src/components/siteHeader/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useContext } from "react";
 import AppBar from "@mui/material/AppBar";
 import Toolbar from "@mui/material/Toolbar";
 import Typography from "@mui/material/Typography";
@@ -13,6 +13,7 @@ import { useNavigate } from "react-router-dom";
 import { useTheme } from "@mui/material/styles";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import { useAuth } from "../../hooks/useAuth";
+import { MoviesContext } from "../../contexts/moviesContext";
 
 const styles = {
   title: {
@@ -34,7 +35,11 @@ const SiteHeader = () => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("lg"));
   const { session }  = useAuth();
-  console.log(session);
+  const moviesContext = useContext(MoviesContext);
+
+  useEffect(() => {
+    moviesContext.getUserFavourites(session?.user?.id);
+  }, []);
 
   const limitedOptions = [
     { label: "Home", path: "/" },

--- a/app/src/components/siteHeader/index.jsx
+++ b/app/src/components/siteHeader/index.jsx
@@ -34,7 +34,6 @@ const SiteHeader = () => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("lg"));
   const { session }  = useAuth();
-  console.log("Session: ", session);
 
   const limitedOptions = [
     { label: "Home", path: "/" },

--- a/app/src/components/siteHeader/index.jsx
+++ b/app/src/components/siteHeader/index.jsx
@@ -34,6 +34,7 @@ const SiteHeader = () => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("lg"));
   const { session }  = useAuth();
+  console.log(session);
 
   const limitedOptions = [
     { label: "Home", path: "/" },

--- a/app/src/contexts/moviesContext.jsx
+++ b/app/src/contexts/moviesContext.jsx
@@ -1,16 +1,38 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { getUserSelection } from "../api/supabase";
+import { useAuth } from "../hooks/useAuth";
 import { supabaseClient } from "../utils/client";
 
 export const MoviesContext = React.createContext(null);
 
-const userFavourites = await getUserSelection("favourites");
-const userWatchlist = await getUserSelection("watchlist");
-
 const MoviesContextProvider = (props) => {
-  const [favourites, setFavourites] = useState(userFavourites);
-  const [watchlist, setWatchlist] = useState(userWatchlist);
-  const [myReviews, setMyReviews] = useState( {} )
+  const { session }  = useAuth();
+  const [favourites, setFavourites] = useState( [] );
+  const [watchlist, setWatchlist] = useState( [] );
+  const [myReviews, setMyReviews] = useState( {} );
+
+  useEffect(() => {
+    getUserFavourites(session?.user?.id);
+    getUserWatchlist(session?.user?.id);
+  }, [session]);
+
+  const getUserFavourites = async (user) => {
+    let userFavourites = await getUserSelection("favourites", user);
+    if(userFavourites === undefined){
+      setFavourites([]);
+    }else{
+      setFavourites(userFavourites);
+    }
+  }
+
+  const getUserWatchlist = async (user) => {
+    let userWatchlist = await getUserSelection("watchlist", user);
+    if(userWatchlist === undefined){
+      setWatchlist([]);
+    }else{
+      setWatchlist(userWatchlist);
+    }
+  }
 
   const addToFavourites = async (movie, user) => {
     try{
@@ -93,6 +115,8 @@ const MoviesContextProvider = (props) => {
       value={{
         favourites,
         watchlist,
+        getUserFavourites,
+        getUserWatchlist,
         addToFavourites,
         removeFromFavourites,
         addToWatchlist,

--- a/app/src/contexts/moviesContext.jsx
+++ b/app/src/contexts/moviesContext.jsx
@@ -12,10 +12,12 @@ const MoviesContextProvider = (props) => {
   const [myReviews, setMyReviews] = useState( {} );
 
   useEffect(() => {
+    //Setup favourites and watchlist from user data present in database
     getUserFavourites(session?.user?.id);
     getUserWatchlist(session?.user?.id);
   }, [session]);
 
+  // Get users favourites from database, populate server state
   const getUserFavourites = async (user) => {
     let userFavourites = await getUserSelection("favourites", user);
     if(userFavourites === undefined){
@@ -25,6 +27,7 @@ const MoviesContextProvider = (props) => {
     }
   }
 
+  // Get users watchlist items from database, populate server state
   const getUserWatchlist = async (user) => {
     let userWatchlist = await getUserSelection("watchlist", user);
     if(userWatchlist === undefined){
@@ -39,8 +42,7 @@ const MoviesContextProvider = (props) => {
         let updatedFavourites = [...favourites];
         if(!favourites.includes(movie.id)) {
           // add to supabase DB table "favourites"
-          let { error } = await supabaseClient
-            .from("favourites").insert({id: movie.id, user_id: user});
+          let { error } = await supabaseClient.from("favourites").insert({id: movie.id, user_id: user});
           // if no error returned from supabase, add to server state
           if(!error){
             updatedFavourites.push(movie.id);
@@ -56,16 +58,13 @@ const MoviesContextProvider = (props) => {
 
   const removeFromFavourites = async (movie, user) => {
     try{
-      let { error } = await supabaseClient
-        .from("favourites").delete().eq("id", movie.id).eq("user_id", user);
-
+      let { error } = await supabaseClient.from("favourites").delete().eq("id", movie.id).eq("user_id", user);
       if(!error){
         //remove from server state
         setFavourites(favourites.filter((mId) => mId !== movie.id));
       }else{
         throw error;
       }
-    
     }catch(err){
       console.log(err);
     }
@@ -75,9 +74,7 @@ const MoviesContextProvider = (props) => {
     try{
       let updatedWatchlist = [...watchlist];
       if(!watchlist.includes(movie.id)) {
-        let { error } = await supabaseClient
-        .from("watchlist").insert({id: movie.id, user_id: user});
-      
+        let { error } = await supabaseClient.from("watchlist").insert({id: movie.id, user_id: user});
         if(!error){
           updatedWatchlist.push(movie.id)
         }else{
@@ -92,8 +89,7 @@ const MoviesContextProvider = (props) => {
 
   const removeFromWatchlist = async (movie, user) => {
     try{
-      let { error } = await supabaseClient
-        .from("watchlist").delete().eq("id", movie.id).eq("user_id", user);
+      let { error } = await supabaseClient.from("watchlist").delete().eq("id", movie.id).eq("user_id", user);
       
       if(!error){
         setWatchlist(watchlist.filter((mId) => mId !== movie.id));

--- a/app/src/contexts/moviesContext.jsx
+++ b/app/src/contexts/moviesContext.jsx
@@ -12,13 +12,13 @@ const MoviesContextProvider = (props) => {
   const [watchlist, setWatchlist] = useState(userWatchlist);
   const [myReviews, setMyReviews] = useState( {} )
 
-  const addToFavourites = async (movie) => {
+  const addToFavourites = async (movie, user) => {
     try{
         let updatedFavourites = [...favourites];
         if(!favourites.includes(movie.id)) {
           // add to supabase DB table "favourites"
           let { error } = await supabaseClient
-            .from("favourites").insert({id: movie.id});
+            .from("favourites").insert({id: movie.id, user_id: user});
           // if no error returned from supabase, add to server state
           if(!error){
             updatedFavourites.push(movie.id);
@@ -32,10 +32,10 @@ const MoviesContextProvider = (props) => {
     }
   }
 
-  const removeFromFavourites = async (movie) => {
+  const removeFromFavourites = async (movie, user) => {
     try{
       let { error } = await supabaseClient
-        .from("favourites").delete().eq("id", movie.id);
+        .from("favourites").delete().eq("id", movie.id).eq("user_id", user);
 
       if(!error){
         //remove from server state
@@ -49,12 +49,12 @@ const MoviesContextProvider = (props) => {
     }
   };
 
-  const addToWatchlist = async (movie) => {
+  const addToWatchlist = async (movie, user) => {
     try{
       let updatedWatchlist = [...watchlist];
       if(!watchlist.includes(movie.id)) {
         let { error } = await supabaseClient
-        .from("watchlist").insert({id: movie.id});
+        .from("watchlist").insert({id: movie.id, user_id: user});
       
         if(!error){
           updatedWatchlist.push(movie.id)
@@ -68,10 +68,10 @@ const MoviesContextProvider = (props) => {
     }
   }
 
-  const removeFromWatchlist = async (movie) => {
+  const removeFromWatchlist = async (movie, user) => {
     try{
       let { error } = await supabaseClient
-        .from("watchlist").delete().eq("id", movie.id);
+        .from("watchlist").delete().eq("id", movie.id).eq("user_id", user);
       
       if(!error){
         setWatchlist(watchlist.filter((mId) => mId !== movie.id));

--- a/app/src/index.jsx
+++ b/app/src/index.jsx
@@ -32,21 +32,21 @@ const App = () => {
       <BrowserRouter>
         <AuthContextProvider>
           <MoviesContextProvider>
-            <SiteHeader />
-              <Routes>
-                <Route path="/movies/upcoming" element={<UpcomingMovies />} />
-                <Route path="/movies/favourites" element={<FavouriteMoviesPage />} />
-                <Route path="/movies/watchlist" element={<WatchlistMoviesPage />} />
-                <Route path="/reviews/form" element={<AddMovieReviewPage/>} />
-                <Route path="/movies/:id" element={<MoviePage />} />
-                <Route path="/reviews/:id" element={<MovieReviewPage/>} />
-                <Route path="/" element={<HomePage />} />
-                <Route path="/login" element={<LoginPage />} />
-                <Route path="/logout" element={<SignOut />} />
-                <Route path="*" element={<Navigate to="/" />} />
-              </Routes>
-          </MoviesContextProvider>
-          </AuthContextProvider>
+              <SiteHeader />
+                <Routes>
+                  <Route path="/movies/upcoming" element={<UpcomingMovies />} />
+                  <Route path="/movies/favourites" element={<FavouriteMoviesPage />} />
+                  <Route path="/movies/watchlist" element={<WatchlistMoviesPage />} />
+                  <Route path="/reviews/form" element={<AddMovieReviewPage/>} />
+                  <Route path="/movies/:id" element={<MoviePage />} />
+                  <Route path="/reviews/:id" element={<MovieReviewPage/>} />
+                  <Route path="/" element={<HomePage />} />
+                  <Route path="/login" element={<LoginPage />} />
+                  <Route path="/logout" element={<SignOut />} />
+                  <Route path="*" element={<Navigate to="/" />} />
+                </Routes>
+            </MoviesContextProvider>
+        </AuthContextProvider>
       </BrowserRouter>
       <ReactQueryDevtools initialIsOpen={false} />
     </QueryClientProvider>

--- a/app/src/pages/homePage.jsx
+++ b/app/src/pages/homePage.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useContext } from "react";
 import PageTemplate from "../components/templateMovieListPage";
 import { useQuery } from "react-query";
 import Spinner from "../components/spinner";
@@ -28,6 +28,7 @@ const HomePage = (props) => {
     [],
     [titleFiltering, genreFiltering]
   );
+  
   const { session }  = useAuth();
 
   if (isLoading) {

--- a/app/src/pages/homePage.jsx
+++ b/app/src/pages/homePage.jsx
@@ -5,6 +5,7 @@ import Spinner from "../components/spinner";
 import { getMovies } from "../api/tmdb-api";
 import useFiltering from "../hooks/useFiltering";
 import AddToFavouritesIcon from '../components/cardIcons/addToFavourites'
+import { useAuth } from "../hooks/useAuth";
 import MovieFilterUI, {
   titleFilter,
   genreFilter,
@@ -27,6 +28,7 @@ const HomePage = (props) => {
     [],
     [titleFiltering, genreFiltering]
   );
+  const { session }  = useAuth();
 
   if (isLoading) {
     return <Spinner />;
@@ -50,6 +52,7 @@ const HomePage = (props) => {
 
   return (
     <>
+    {session ? (
       <PageTemplate
         title="Discover Movies"
         movies={displayedMovies}
@@ -57,6 +60,11 @@ const HomePage = (props) => {
           return <AddToFavouritesIcon movie={movie} />
         }}
       />
+    ):(<PageTemplate
+      title="Discover Movies"
+      movies={displayedMovies}
+      action={() => {}} />
+    )}
       <MovieFilterUI
         onFilterValuesChange={changeFilterValues}
         titleFilter={filterValues[0].value}

--- a/app/src/pages/upcomingMovies.jsx
+++ b/app/src/pages/upcomingMovies.jsx
@@ -4,10 +4,12 @@ import PageTemplate from '../components/templateMovieListPage'
 import AddToWatchlistIcon from '../components/cardIcons/addToWatchlist'
 import { useQuery } from "react-query";
 import { getUpcomingMovies } from "../api/tmdb-api";
+import { useAuth } from "../hooks/useAuth";
 
 const UpcomingMovies = (props) => {
 
   const { data, error, isLoading, isError } = useQuery("upcoming", getUpcomingMovies);
+  const { session }  = useAuth();
 
   if (isLoading) {
     return <Spinner />;
@@ -20,13 +22,22 @@ const UpcomingMovies = (props) => {
   const movies = data ? data.results : [];
 
   return (
-    <PageTemplate
+    <>
+    {session ? (
+      <PageTemplate
       title='Upcoming Movies'
       movies={movies}
       action={(movie) => {
         return <AddToWatchlistIcon movie={movie} />
       }}
     />
+    ): (
+      <PageTemplate
+      title='Upcoming Movies'
+      movies={movies}
+      action={() => {}} />
+    )}
+  </>
   );
 };
 export default UpcomingMovies;


### PR DESCRIPTION
closes #20 

## Description

The refactors made in this issue explicitly link a users account with items from selected favourites and watchlist, once a user is logged in, their selections are reflected in the "discover", "upcoming", "favourites" and "watchlist" pages, populated from Supabase. In addition, while any user can view the "discover" and "upcoming" pages, only signed in users have access to view their selections, or to see/access the icons to add favourites and watchlist items. 

The work to be done here is to verify this functionality works as intended.

## Tests

### Test 1 - Verify signed in/signed out options display correctly

Verify that while signed out, users can only see the "home", "upcoming" and "login" options, and that the add to favourites/watchlist buttons are not available.

Verify that while signed in, users can see all currently available options

### Test 2 - Verify adding of items per user

Ensure that items can be added, and that they persist when logged out and back in.